### PR TITLE
Add endpoint on User identity

### DIFF
--- a/Model/Identity/User.php
+++ b/Model/Identity/User.php
@@ -34,6 +34,13 @@ class User extends AbstractIdentity
     protected $region;
 
     /**
+     * @var string AWS API Endpoint
+     *
+     * @Identity()
+     */
+    protected $endpoint;
+
+    /**
      * Set AWS API Key
      *
      * @param string $key AWS API Key
@@ -103,5 +110,29 @@ class User extends AbstractIdentity
     public function getRegion()
     {
         return $this->region;
+    }
+
+    /**
+     * Set AWS API Endpoint
+     *
+     * @param string $endpoint AWS API Endpoint
+     *
+     * @return {$this}
+     */
+    public function setEndpoint($endpoint)
+    {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * Get AWS API Endpoint
+     *
+     * @return string AWS API Endpoint
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint;
     }
 }


### PR DESCRIPTION
For me, user is linked to region and endpoint.

To plug in a third service like ElasticMQ (in SQSBundle), we need the endpoint parameter.

Like #1

Tested In two cases : Local (new) and on AWS
